### PR TITLE
Fix autoformat overwriting code and additional flags being ignored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha512-tE1SYtNG3I3atRVPELSGN2FJJJtPg3O/G0tycYSyzeDqdAbdLPRH089LhpWYA5M/iHeWHkVZq/b0OVKngcK0Eg==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.51"
+                "@types/node": "*"
             }
         },
         "@types/node": {
@@ -25,10 +25,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ansi-cyan": {
@@ -82,8 +82,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -116,7 +116,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -180,7 +180,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -195,7 +195,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boom": {
@@ -204,7 +204,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -213,7 +213,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -223,9 +223,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -252,11 +252,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "clone": {
@@ -283,9 +283,9 @@
             "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "1.0.7",
-                "through2": "2.0.3"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^1.0.6",
+                "through2": "^2.0.1"
             }
         },
         "co": {
@@ -306,7 +306,7 @@
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -339,7 +339,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "dashdash": {
@@ -348,7 +348,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -380,7 +380,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "delayed-stream": {
@@ -407,7 +407,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -422,10 +422,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -442,10 +442,10 @@
             "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -455,7 +455,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -464,7 +464,7 @@
             "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -479,13 +479,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -494,7 +494,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -503,7 +503,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "extend": {
@@ -518,7 +518,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
         "extglob": {
@@ -527,7 +527,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -550,9 +550,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -573,7 +573,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -588,11 +588,11 @@
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "first-chunk-stream": {
@@ -613,7 +613,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -628,9 +628,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -651,10 +651,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "generate-function": {
@@ -669,7 +669,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "getpass": {
@@ -678,7 +678,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -695,12 +695,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -709,8 +709,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -719,7 +719,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -734,7 +734,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -745,8 +745,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -755,14 +755,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -771,11 +771,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -790,10 +790,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -808,8 +808,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -820,7 +820,7 @@
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -841,9 +841,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -852,9 +852,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -863,8 +863,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -879,10 +879,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -897,8 +897,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -909,11 +909,11 @@
             "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "~3.3.4",
+                "node.extend": "~1.1.2",
+                "request": "~2.79.0",
+                "through2": "~2.0.3",
+                "vinyl": "~2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -934,26 +934,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "vinyl": {
@@ -962,13 +962,13 @@
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^1.0.0",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "is-stream": "^1.1.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -979,11 +979,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -1004,8 +1004,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1017,10 +1017,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-untar": {
@@ -1029,11 +1029,11 @@
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -1042,24 +1042,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -1092,8 +1092,8 @@
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1105,13 +1105,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -1132,7 +1132,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "vinyl": {
@@ -1141,12 +1141,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1157,7 +1157,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.0"
+                "glogg": "^1.0.0"
             }
         },
         "har-schema": {
@@ -1172,10 +1172,10 @@
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.12.2",
-                "is-my-json-valid": "2.17.1",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -1184,7 +1184,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1199,7 +1199,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "hawk": {
@@ -1208,10 +1208,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -1232,9 +1232,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1243,8 +1243,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1277,7 +1277,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1298,7 +1298,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-my-json-valid": {
@@ -1307,10 +1307,10 @@
             "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-number": {
@@ -1319,7 +1319,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1328,7 +1328,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1427,7 +1427,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1480,7 +1480,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "lodash._basecopy": {
@@ -1543,7 +1543,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -1570,9 +1570,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -1587,15 +1587,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -1604,8 +1604,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "map-stream": {
@@ -1620,7 +1620,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -1629,19 +1629,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1650,7 +1650,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -1665,7 +1665,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -1674,7 +1674,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1691,7 +1691,7 @@
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "minimatch": {
@@ -1700,7 +1700,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -1748,7 +1748,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -1765,10 +1765,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -1786,7 +1786,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -1795,7 +1795,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "oauth-sign": {
@@ -1816,8 +1816,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "once": {
@@ -1826,7 +1826,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "ordered-read-streams": {
@@ -1835,15 +1835,14 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.3"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-            "dev": true
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "parse-glob": {
             "version": "3.0.4",
@@ -1851,10 +1850,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1869,7 +1868,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1892,7 +1891,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -1919,7 +1918,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -1928,11 +1927,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "preserve": {
@@ -1971,7 +1970,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -1980,8 +1979,8 @@
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -1990,7 +1989,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1999,7 +1998,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2010,7 +2009,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2021,13 +2020,13 @@
             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "regex-cache": {
@@ -2036,7 +2035,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -2069,28 +2068,28 @@
             "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2111,7 +2110,7 @@
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                     }
                 },
                 "caseless": {
@@ -2126,7 +2125,7 @@
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "dev": true,
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -2135,7 +2134,7 @@
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "dev": true,
                             "requires": {
-                                "hoek": "4.2.0"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -2146,9 +2145,9 @@
                     "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.17"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-validator": {
@@ -2157,8 +2156,8 @@
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "hawk": {
@@ -2167,10 +2166,10 @@
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "dev": true,
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.0",
-                        "sntp": "2.1.0"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -2185,9 +2184,9 @@
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "qs": {
@@ -2202,7 +2201,7 @@
                     "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                     }
                 },
                 "tunnel-agent": {
@@ -2211,7 +2210,7 @@
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -2228,7 +2227,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -2249,7 +2248,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -2264,7 +2263,7 @@
             "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             }
         },
         "sparkles": {
@@ -2279,7 +2278,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
@@ -2288,14 +2287,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2318,7 +2317,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -2333,7 +2332,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2348,7 +2347,7 @@
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -2363,7 +2362,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -2372,7 +2371,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -2381,8 +2380,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "supports-color": {
@@ -2397,9 +2396,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -2414,8 +2413,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -2424,8 +2423,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -2438,9 +2437,8 @@
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -2449,7 +2447,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2458,7 +2456,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -2469,7 +2467,7 @@
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tunnel-agent": {
@@ -2497,8 +2495,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "url-parse": {
@@ -2507,8 +2505,8 @@
             "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             }
         },
         "util-deprecate": {
@@ -2535,9 +2533,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2554,8 +2552,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -2564,23 +2562,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.1",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.3",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -2601,8 +2599,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2614,8 +2612,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vscode": {
@@ -2624,20 +2622,20 @@
             "integrity": "sha512-MvFXXSGuhw0Q6GC6dQrnRc0ES+63wpttGIoYGBMQnoS9JFCCNC/rWfX0lBCHJyuKL2Q8CYg0ROsMEHbHVwEtVw==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.83.0",
-                "semver": "5.4.1",
-                "source-map-support": "0.5.0",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src": "^0.4.3",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "wrappy": {
@@ -2658,8 +2656,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -2668,7 +2666,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Runs the Haskell code formatting tool Brittany",
     "version": "0.0.1",
     "publisher": "MaxGabriel",
+    "repository": "https://github.com/MaxGabriel/brittany-vscode-extension",
     "engines": {
         "vscode": "^1.19.0"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,6 @@ export function activate(context: vscode.ExtensionContext) {
             // Improvement TODO: Instead of making a tmp file, pass the source code into STDIN.
             // Could also potentially unify this approach with the full-file approach.
             if (range.isEqual(fullDocumentRange(document))) {
-
                 if (document.isDirty) {
                     vscode.commands.executeCommand('workbench.action.files.saveWithoutFormatting').then(() =>
                         vscode.commands.executeCommand('editor.action.formatDocument').then(
@@ -41,8 +40,6 @@ export function activate(context: vscode.ExtensionContext) {
                 } else {
                     return runBrittany(document, range, document.uri.fsPath, null);
                 }
-
-
             } else {
                 const substring = document.getText(range);
                 const tmpobj = tmp.fileSync();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,16 @@ export function activate(context: vscode.ExtensionContext) {
             // Improvement TODO: Instead of making a tmp file, pass the source code into STDIN.
             // Could also potentially unify this approach with the full-file approach.
             if (range.isEqual(fullDocumentRange(document))) {
-                return runBrittany(document, range, document.uri.fsPath, null);
+
+                if (document.isDirty) {
+                    vscode.commands.executeCommand('workbench.action.files.saveWithoutFormatting').then(() =>
+                        vscode.commands.executeCommand('editor.action.formatDocument').then(
+                            document.save));
+                } else {
+                    return runBrittany(document, range, document.uri.fsPath, null);
+                }
+
+
             } else {
                 const substring = document.getText(range);
                 const tmpobj = tmp.fileSync();
@@ -60,11 +69,11 @@ function runBrittany(document: vscode.TextDocument, range: vscode.Range, inputFi
 
         const file = document.uri.fsPath;
 
-        const cmd = brittanyCmd() + " \"" + inputFilename + "\""; + " " + additionalFlags()
+        const cmd = brittanyCmd() + " \"" + inputFilename + "\"" + " " + additionalFlags();
         const maybeWorkspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-        const dir = maybeWorkspaceFolder !== undefined ? maybeWorkspaceFolder.uri.fsPath : path.dirname(document.uri.fsPath)
+        const dir = maybeWorkspaceFolder !== undefined ? maybeWorkspaceFolder.uri.fsPath : path.dirname(document.uri.fsPath);
         console.log("brittany command is: " + cmd);
-        console.log("brittany folder is: " + dir)
+        console.log("brittany folder is: " + dir);
 
         const options = {
             encoding: 'utf8',
@@ -92,7 +101,7 @@ function runBrittany(document: vscode.TextDocument, range: vscode.Range, inputFi
                     return reject([]);
                 } else {
                     if (tmpobj) { tmpobj.removeCallback(); }
-                    return resolve([vscode.TextEdit.replace(range,stdout)]);
+                    return resolve([vscode.TextEdit.replace(range, stdout)]);
                 }
             }
         );
@@ -104,15 +113,15 @@ export function deactivate() {
 }
 
 function brittanyCmd() {
-	return vscode.workspace.getConfiguration("brittany")["path"];
+    return vscode.workspace.getConfiguration("brittany")["path"];
 }
 
 function additionalFlags() {
-	return vscode.workspace.getConfiguration("brittany")["additional-flags"];
+    return vscode.workspace.getConfiguration("brittany")["additional-flags"];
 }
 
 function isEnabled() {
-	return vscode.workspace.getConfiguration("brittany")["enable"];
+    return vscode.workspace.getConfiguration("brittany")["enable"];
 }
 
 function fullDocumentRange(document: vscode.TextDocument): vscode.Range {


### PR DESCRIPTION
Added a workaround to fix the bug specified in #1.

This fix makes sure to save the file without formatting before letting it be formatted with Brittany. The original bug came from the fact that in vs-code, saving with auto-format turned on will format before saving. Since this extension calls Brittany from the command line, it will look at the local (previously saved) file instead of the file as it is within the editor, effectively discarding any changes. Saving without formatting, then formatting, and finally saving again is the current workaround I have implemented that makes it work correctly while still functioning like other formatting extensions. In the future, it may be better to find a way to read the file directly from vs-code instead of going to the filesystem.


This pull request also moves a premature semicolon on line 72 that prevents the additional flags from being added to the command.  Missing semicolons are added where necessary. The 3 places that used tabs used for indentation are replaced with spaces.
