### PR TITLE
Support for Brittany through Stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
                     "default": true,
                     "description": "Whether the extension should be enabled."
                 },
+                "brittany.stack-enable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether the extension should use brittany through stack (stack exec brittany) instead of brittany on the PATH."
+                },
                 "brittany.additional-flags": {
                     "type": "string",
                     "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,9 +64,13 @@ export function activate(context: vscode.ExtensionContext) {
 function runBrittany(document: vscode.TextDocument, range: vscode.Range, inputFilename: string, tmpobj): Thenable<vscode.TextEdit[]> {
     return new Promise((resolve, reject) => {
 
-        const file = document.uri.fsPath;
+        let cmd;
+        if (isStackEnabled()) {
+            cmd = "stack exec brittany" + " \"" + inputFilename + "\"" + " -- " + additionalFlags();
+        } else {
+            cmd = brittanyCmd() + " \"" + inputFilename + "\"" + " " + additionalFlags();
+        }
 
-        const cmd = brittanyCmd() + " \"" + inputFilename + "\"" + " " + additionalFlags();
         const maybeWorkspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
         const dir = maybeWorkspaceFolder !== undefined ? maybeWorkspaceFolder.uri.fsPath : path.dirname(document.uri.fsPath);
         console.log("brittany command is: " + cmd);
@@ -120,6 +124,11 @@ function additionalFlags() {
 function isEnabled() {
     return vscode.workspace.getConfiguration("brittany")["enable"];
 }
+
+function isStackEnabled() {
+    return vscode.workspace.getConfiguration("brittany")["stack-enable"];
+}
+
 
 function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
     const lastLineId = document.lineCount - 1;


### PR DESCRIPTION
Added a configuration flag to choose whether to use Brittany from the PATH, or through "stack exec brittany". The generated command is different depending on whether the flag is true or not. Default is to use Brittany from the PATH. 