### PR TITLE
Supports most recent Formatting API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,10 @@
             "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
             }
         },
         "ansi-cyan": {
@@ -64,7 +64,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "^1.0.0"
+                "buffer-equal": "1.0.0"
             }
         },
         "arr-diff": {
@@ -73,8 +73,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.0.1",
-                "array-slice": "^0.2.3"
+                "arr-flatten": "1.1.0",
+                "array-slice": "0.2.3"
             }
         },
         "arr-flatten": {
@@ -107,7 +107,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -128,7 +128,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "assert-plus": {
@@ -167,7 +167,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "block-stream": {
@@ -176,7 +176,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "brace-expansion": {
@@ -185,7 +185,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -243,9 +243,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "combined-stream": {
@@ -254,7 +254,7 @@
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -275,7 +275,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "core-util-is": {
@@ -290,7 +290,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "debug": {
@@ -308,7 +308,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "define-properties": {
@@ -317,7 +317,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.0.12"
             }
         },
         "delayed-stream": {
@@ -344,10 +344,10 @@
             "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -356,8 +356,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "end-of-stream": {
@@ -366,7 +366,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -381,13 +381,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
             }
         },
         "extend": {
@@ -402,7 +402,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "^1.1.0"
+                "kind-of": "1.1.0"
             }
         },
         "extsprintf": {
@@ -429,7 +429,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "flush-write-stream": {
@@ -438,8 +438,8 @@
             "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.3.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "forever-agent": {
@@ -454,9 +454,9 @@
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.21"
             }
         },
         "from": {
@@ -471,8 +471,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "through2": "^2.0.3"
+                "graceful-fs": "4.1.15",
+                "through2": "2.0.5"
             }
         },
         "fs.realpath": {
@@ -487,10 +487,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.15",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.3"
             }
         },
         "function-bind": {
@@ -505,7 +505,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -514,12 +514,12 @@
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-parent": {
@@ -528,8 +528,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             }
         },
         "glob-stream": {
@@ -538,16 +538,16 @@
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
-                "is-negated-glob": "^1.0.0",
-                "ordered-read-streams": "^1.0.0",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.1.5",
-                "remove-trailing-separator": "^1.0.1",
-                "to-absolute-glob": "^2.0.0",
-                "unique-stream": "^2.0.2"
+                "extend": "3.0.2",
+                "glob": "7.1.3",
+                "glob-parent": "3.1.0",
+                "is-negated-glob": "1.0.0",
+                "ordered-read-streams": "1.0.1",
+                "pumpify": "1.5.1",
+                "readable-stream": "2.3.6",
+                "remove-trailing-separator": "1.1.0",
+                "to-absolute-glob": "2.0.2",
+                "unique-stream": "2.3.1"
             }
         },
         "graceful-fs": {
@@ -568,9 +568,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.5"
             }
         },
         "gulp-filter": {
@@ -579,9 +579,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
             }
         },
         "gulp-gunzip": {
@@ -590,8 +590,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -606,10 +606,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -624,8 +624,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -637,10 +637,10 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
+                "node.extend": "1.1.8",
+                "request": "2.88.0",
+                "through2": "2.0.5",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -661,12 +661,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -677,11 +677,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "~3.3.4",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3",
-                "vinyl": "^1.2.0"
+                "event-stream": "3.3.4",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.5",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -702,8 +702,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -716,12 +716,12 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^3.0.3",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
+                "queue": "4.5.1",
+                "through2": "2.0.5",
+                "vinyl": "2.2.0",
+                "vinyl-fs": "3.0.3",
+                "yauzl": "2.10.0",
+                "yazl": "2.5.1"
             },
             "dependencies": {
                 "clone": {
@@ -742,12 +742,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -764,8 +764,8 @@
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.8.1",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -774,7 +774,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-flag": {
@@ -801,9 +801,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.16.1"
             }
         },
         "inflight": {
@@ -812,8 +812,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -834,8 +834,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.2"
             }
         },
         "is-buffer": {
@@ -856,7 +856,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
             }
         },
         "is-negated-glob": {
@@ -877,7 +877,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "^1.0.0"
+                "is-unc-path": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -892,7 +892,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "^0.1.2"
+                "unc-path-regex": "0.1.2"
             }
         },
         "is-utf8": {
@@ -979,7 +979,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.3.6"
             }
         },
         "lead": {
@@ -988,7 +988,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "^1.0.2"
+                "flush-write-stream": "1.1.1"
             }
         },
         "map-stream": {
@@ -1009,7 +1009,7 @@
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.37.0"
             }
         },
         "minimatch": {
@@ -1018,7 +1018,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -1060,12 +1060,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -1082,10 +1082,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
             }
         },
         "node.extend": {
@@ -1094,8 +1094,8 @@
             "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "has": "^1.0.3",
-                "is": "^3.2.1"
+                "has": "1.0.3",
+                "is": "3.3.0"
             }
         },
         "normalize-path": {
@@ -1104,7 +1104,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "now-and-later": {
@@ -1113,7 +1113,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "^1.3.2"
+                "once": "1.4.0"
             }
         },
         "oauth-sign": {
@@ -1134,10 +1134,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "1.1.3",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.12"
             }
         },
         "once": {
@@ -1146,7 +1146,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "ordered-read-streams": {
@@ -1155,7 +1155,7 @@
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "os-tmpdir": {
@@ -1181,7 +1181,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "~2.3"
+                "through": "2.3.8"
             }
         },
         "pend": {
@@ -1202,11 +1202,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
             }
         },
         "process-nextick-args": {
@@ -1227,8 +1227,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -1237,9 +1237,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.7.1",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -1266,7 +1266,7 @@
             "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "readable-stream": {
@@ -1275,13 +1275,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "remove-bom-buffer": {
@@ -1290,8 +1290,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "^1.1.5",
-                "is-utf8": "^0.2.1"
+                "is-buffer": "1.1.6",
+                "is-utf8": "0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -1300,9 +1300,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "^3.0.0",
-                "safe-buffer": "^5.1.0",
-                "through2": "^2.0.3"
+                "remove-bom-buffer": "3.0.0",
+                "safe-buffer": "5.1.2",
+                "through2": "2.0.5"
             }
         },
         "remove-trailing-separator": {
@@ -1323,26 +1323,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.21",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "requires-port": {
@@ -1357,7 +1357,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "^3.0.0"
+                "value-or-function": "3.0.0"
             }
         },
         "rimraf": {
@@ -1366,7 +1366,7 @@
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.3"
+                "glob": "7.1.3"
             }
         },
         "safe-buffer": {
@@ -1399,8 +1399,8 @@
             "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
             }
         },
         "split": {
@@ -1409,7 +1409,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2"
+                "through": "2.3.8"
             }
         },
         "sshpk": {
@@ -1418,15 +1418,15 @@
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "stat-mode": {
@@ -1441,7 +1441,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "stream-shift": {
@@ -1456,7 +1456,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
             }
         },
         "streamifier": {
@@ -1471,7 +1471,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "supports-color": {
@@ -1480,7 +1480,7 @@
             "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
             "dev": true,
             "requires": {
-                "has-flag": "^2.0.0"
+                "has-flag": "2.0.0"
             }
         },
         "tar": {
@@ -1489,9 +1489,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "through": {
@@ -1506,8 +1506,8 @@
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "through2-filter": {
@@ -1516,8 +1516,8 @@
             "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
             "dev": true,
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
+                "through2": "2.0.5",
+                "xtend": "4.0.1"
             }
         },
         "tmp": {
@@ -1525,7 +1525,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -1534,8 +1534,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
+                "is-absolute": "1.0.0",
+                "is-negated-glob": "1.0.0"
             }
         },
         "to-through": {
@@ -1544,7 +1544,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3"
+                "through2": "2.0.5"
             }
         },
         "tough-cookie": {
@@ -1553,8 +1553,8 @@
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
+                "psl": "1.1.31",
+                "punycode": "1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -1571,7 +1571,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -1598,8 +1598,8 @@
             "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
             "dev": true,
             "requires": {
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "through2-filter": "^3.0.0"
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "through2-filter": "3.0.0"
             }
         },
         "uri-js": {
@@ -1608,7 +1608,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "url-parse": {
@@ -1617,8 +1617,8 @@
             "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "dev": true,
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.1.0",
+                "requires-port": "1.0.0"
             }
         },
         "util-deprecate": {
@@ -1645,9 +1645,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vinyl": {
@@ -1656,8 +1656,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "^0.2.0",
-                "clone-stats": "^0.0.1"
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
             }
         },
         "vinyl-fs": {
@@ -1666,23 +1666,23 @@
             "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "fs-mkdirp-stream": "^1.0.0",
-                "glob-stream": "^6.1.0",
-                "graceful-fs": "^4.0.0",
-                "is-valid-glob": "^1.0.0",
-                "lazystream": "^1.0.0",
-                "lead": "^1.0.0",
-                "object.assign": "^4.0.4",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.3.3",
-                "remove-bom-buffer": "^3.0.0",
-                "remove-bom-stream": "^1.2.0",
-                "resolve-options": "^1.1.0",
-                "through2": "^2.0.0",
-                "to-through": "^2.0.0",
-                "value-or-function": "^3.0.0",
-                "vinyl": "^2.0.0",
-                "vinyl-sourcemap": "^1.1.0"
+                "fs-mkdirp-stream": "1.0.0",
+                "glob-stream": "6.1.0",
+                "graceful-fs": "4.1.15",
+                "is-valid-glob": "1.0.0",
+                "lazystream": "1.0.0",
+                "lead": "1.0.0",
+                "object.assign": "4.1.0",
+                "pumpify": "1.5.1",
+                "readable-stream": "2.3.6",
+                "remove-bom-buffer": "3.0.0",
+                "remove-bom-stream": "1.2.0",
+                "resolve-options": "1.1.0",
+                "through2": "2.0.5",
+                "to-through": "2.0.0",
+                "value-or-function": "3.0.0",
+                "vinyl": "2.2.0",
+                "vinyl-sourcemap": "1.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -1703,12 +1703,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -1719,8 +1719,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
+                "through2": "2.0.5",
+                "vinyl": "0.4.6"
             }
         },
         "vinyl-sourcemap": {
@@ -1729,13 +1729,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "^1.0.2",
-                "convert-source-map": "^1.5.0",
-                "graceful-fs": "^4.1.6",
-                "normalize-path": "^2.1.1",
-                "now-and-later": "^2.0.0",
-                "remove-bom-buffer": "^3.0.0",
-                "vinyl": "^2.0.0"
+                "append-buffer": "1.0.2",
+                "convert-source-map": "1.6.0",
+                "graceful-fs": "4.1.15",
+                "normalize-path": "2.1.1",
+                "now-and-later": "2.0.0",
+                "remove-bom-buffer": "3.0.0",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1756,12 +1756,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -1772,20 +1772,20 @@
             "integrity": "sha512-E6hzqGtCD65BnBxdZzSIi8FPCM4seEEK/bbTeYdJntg+4D5R6GLbdYFySE9DNTtMJF4iB9UGoucKU/p8Guts1g==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
+                "glob": "7.1.3",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.1",
-                "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.2",
-                "mocha": "^4.0.1",
-                "request": "^2.88.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.3",
-                "vinyl-fs": "^3.0.3",
-                "vinyl-source-stream": "^1.1.0"
+                "gulp-remote-src-vscode": "0.5.1",
+                "gulp-untar": "0.0.7",
+                "gulp-vinyl-zip": "2.1.2",
+                "mocha": "4.1.0",
+                "request": "2.88.0",
+                "semver": "5.6.0",
+                "source-map-support": "0.5.10",
+                "url-parse": "1.4.4",
+                "vinyl-fs": "3.0.3",
+                "vinyl-source-stream": "1.1.2"
             }
         },
         "wrappy": {
@@ -1806,8 +1806,8 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.1.0"
             }
         },
         "yazl": {
@@ -1816,7 +1816,7 @@
             "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3"
+                "buffer-crc32": "0.2.13"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/runtime": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+            "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+            "requires": {
+                "regenerator-runtime": "0.12.1"
+            }
+        },
         "@types/mocha": {
             "version": "2.2.48",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -1158,11 +1166,6 @@
                 "readable-stream": "2.3.6"
             }
         },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-        },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -1214,6 +1217,14 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
             "dev": true
+        },
+        "promisify-child-process": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-3.1.0.tgz",
+            "integrity": "sha512-qSXQUk7eci66DGQ62Joo5k8Li5x+WsloaM+oPPeKY549suS4ZIvi/qj2POsLlsG8a6RzBSZezvYHw75mcn7WmQ==",
+            "requires": {
+                "@babel/runtime": "7.3.1"
+            }
         },
         "psl": {
             "version": "1.1.31",
@@ -1283,6 +1294,11 @@
                 "string_decoder": "1.1.1",
                 "util-deprecate": "1.0.2"
             }
+        },
+        "regenerator-runtime": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+            "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         },
         "remove-bom-buffer": {
             "version": "3.0.0",
@@ -1518,14 +1534,6 @@
             "requires": {
                 "through2": "2.0.5",
                 "xtend": "4.0.1"
-            }
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "requires": {
-                "os-tmpdir": "1.0.2"
             }
         },
         "to-absolute-glob": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "Formatters"
     ],
     "activationEvents": [
-        "*"
+        "onLanguage:haskell"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -1,67 +1,67 @@
 {
-    "name": "brittany",
-    "displayName": "brittany",
-    "description": "Runs the Haskell code formatting tool Brittany",
-    "version": "0.0.3",
-    "publisher": "MaxGabriel",
-    "repository": "https://github.com/MaxGabriel/brittany-vscode-extension",
-    "engines": {
-        "vscode": "^1.19.0"
-    },
-    "categories": [
-        "Formatters"
-    ],
-    "activationEvents": [
-        "onLanguage:haskell"
-    ],
-    "main": "./out/extension",
-    "contributes": {
-        "configuration": {
-            "title": "brittany configuration",
-            "type": "object",
-            "properties": {
-                "brittany.path": {
-                    "type": "string",
-                    "default": "brittany",
-                    "description": "Path to the brittany executable. This will be wrapped in double quotes to escape it, so your path can e.g. include spaces."
-                },
-                "brittany.enable": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether the extension should be enabled."
-                },
-                "brittany.stackEnable": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether the extension should use brittany through stack (stack exec brittany) instead of brittany on the PATH."
-                },
-                "brittany.additionalFlags": {
-                    "type": "string",
-                    "default": "",
-                    "description": "Additional flags to pass to brittany, e.g. --indent AMOUNT. These are unescaped. They should not attempt to change the input or output files. This option mostly exists as an escape hatch—you should generally prefer editing your brittany config file if possible."
-                },
-                "brittany.keepCRLF": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether the extension should replace CRLF endings with LF. Upstream issues with brittany will introduce unneccessary new lines if this is on."
-                }
-            }
+  "name": "brittany",
+  "displayName": "brittany",
+  "description": "Runs the Haskell code formatting tool Brittany",
+  "version": "0.0.3",
+  "publisher": "MaxGabriel",
+  "repository": "https://github.com/MaxGabriel/brittany-vscode-extension",
+  "engines": {
+    "vscode": "^1.19.0"
+  },
+  "categories": [
+    "Formatters"
+  ],
+  "activationEvents": [
+    "onLanguage:haskell"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "configuration": {
+      "title": "brittany configuration",
+      "type": "object",
+      "properties": {
+        "brittany.path": {
+          "type": "string",
+          "default": "brittany",
+          "description": "Path to the brittany executable. This will be wrapped in double quotes to escape it, so your path can e.g. include spaces."
+        },
+        "brittany.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the extension should be enabled."
+        },
+        "brittany.stackEnable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the extension should use brittany through stack (stack exec brittany) instead of brittany on the PATH."
+        },
+        "brittany.additionalFlags": {
+          "type": "string",
+          "default": "",
+          "description": "Additional flags to pass to brittany, e.g. --indent AMOUNT. These are unescaped. They should not attempt to change the input or output files. This option mostly exists as an escape hatch—you should generally prefer editing your brittany config file if possible."
+        },
+        "brittany.keepCRLF": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the extension should replace CRLF endings with LF. Upstream issues with brittany will introduce unneccessary new lines if this is on."
         }
-    },
-    "scripts": {
-        "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "dependencies": {
-        "tmp": "^0.0.33"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.42",
-        "@types/node": "^7.0.43",
-        "@types/tmp": "0.0.33",
-        "typescript": "^3.1.6",
-        "vscode": "^1.1.21"
+      }
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "dependencies": {
+    "promisify-child-process": "*"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^7.0.43",
+    "@types/tmp": "0.0.33",
+    "typescript": "^3.1.6",
+    "vscode": "^1.1.21"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,133 +1,14 @@
 "use strict";
 
-import * as proc from "child_process";
-import * as fs from "fs";
-import * as path from "path";
-import * as tmp from "tmp";
-import * as vscode from "vscode";
+import { ExtensionContext, languages } from "vscode";
+import Formatter from "./formatter";
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: ExtensionContext): void {
+  const fmt: Formatter = new Formatter();
+  context.subscriptions.push(fmt);
 
-    if (isEnabled() === false) {
-        console.log("brittany extension disabled; not registering it.");
-        return;
-    } else {
-        console.log("registering brittany extension");
-    }
-
-    context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider("haskell", {
-        provideDocumentRangeFormattingEdits(document: vscode.TextDocument,
-                                            range: vscode.Range): Thenable<vscode.TextEdit[]> {
-
-            if (isEnabled() === false) {
-                return new Promise((resolve, reject) => {
-                    return reject([]);
-                });
-            }
-            console.log("brittany asked to format");
-
-            // if document has CRLF line endings, change it to LF.
-            if (!keepCRLF() && document.eol === vscode.EndOfLine.CRLF) {
-                console.log("changing line endings to LF");
-                const LF: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-                LF.set(document.uri, [vscode.TextEdit.setEndOfLine(vscode.EndOfLine.LF)]);
-                vscode.workspace.applyEdit(LF)
-                        .then(() => vscode.commands.executeCommand("workbench.action.files.saveWithoutFormatting"));
-            }
-
-            // if we're formatting the whole document
-            // brittany operates on files only, so we need to
-            // improvement TODO: Instead of making a tmp file, pass the source code into STDIN.
-            // could also potentially unify this approach with the full-file approach.
-            if (range.isEqual(fullDocumentRange(document))) {
-                if (document.isDirty) {
-                    vscode.commands.executeCommand("workbench.action.files.saveWithoutFormatting").then(() =>
-                        vscode.commands.executeCommand("editor.action.formatDocument").then(() =>
-                            vscode.commands.executeCommand("workbench.action.files.saveWithoutFormatting")));
-                } else {
-                    return runBrittany(document, range, document.uri.fsPath, null);
-                }
-            } else {
-                const substring: string = document.getText(range);
-                const tmpobj: tmp.SynchrounousResult = tmp.fileSync();
-                console.log("brittany: Temporary file: ", tmpobj.name);
-                return new Promise((resolve, reject) => {
-                    fs.write(tmpobj.fd, substring, (err: NodeJS.ErrnoException, written: number, str: string) => {
-                        if (err) {
-                            return reject(err);
-                        } else {
-                            return resolve(runBrittany(document, range, tmpobj.name, tmpobj));
-                        }
-                    });
-                });
-            }
-        },
-    }));
-}
-
-function runBrittany(document: vscode.TextDocument, range: vscode.Range,
-                     inputFilename: string, tmpobj: tmp.SynchrounousResult): Thenable<vscode.TextEdit[]> {
-    return new Promise((resolve, reject) => {
-
-        const cmd: string = isStackEnabled()
-            ? `stack exec brittany \"${inputFilename}\" --  ${additionalFlags()}`
-            : `${brittanyCmd()} \"${inputFilename}\" ${additionalFlags()}`;
-        const maybeWorkspaceFolder: vscode.WorkspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-        const dir: string = maybeWorkspaceFolder !== undefined
-            ? maybeWorkspaceFolder.uri.fsPath
-            : path.dirname(document.uri.fsPath);
-        const options
-            : { cwd: string, encoding: string }
-            = { cwd: dir, encoding: "utf8" };
-
-        console.log("brittany command is: " + cmd);
-        console.log("brittany folder is: " + dir);
-
-        proc.exec(
-            cmd,
-            options,
-            (error: Error, stdout: string, stderr: string) => {
-                if (error) {
-                    if (tmpobj) { tmpobj.removeCallback(); }
-                    console.error("Error running brittany:");
-                    console.error(error);
-                    console.error(stdout);
-                    console.error(stderr);
-                    vscode.window.showErrorMessage(
-                        "Failed to run brittany; see the developer tools console for details. " +
-                        error
-                    );
-                    return reject([]);
-                } else {
-                    if (tmpobj) { tmpobj.removeCallback(); }
-                    return resolve([vscode.TextEdit.replace(range, stdout)]);
-                }
-            },
-        );
-    });
-}
-
-function brittanyCmd(): string {
-    return vscode.workspace.getConfiguration("brittany").path;
-}
-
-function additionalFlags(): string {
-    return vscode.workspace.getConfiguration("brittany").additionalFlags;
-}
-
-function isEnabled(): boolean {
-    return vscode.workspace.getConfiguration("brittany").enable;
-}
-
-function isStackEnabled(): boolean {
-    return vscode.workspace.getConfiguration("brittany").stackEnable;
-}
-
-function keepCRLF(): boolean {
-    return vscode.workspace.getConfiguration("brittany").keepCRLF;
-}
-
-function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
-    const lastLineId: number = document.lineCount - 1;
-    return new vscode.Range(0, 0, lastLineId, document.lineAt(lastLineId).text.length);
+  context.subscriptions.push(
+    languages.registerDocumentRangeFormattingEditProvider("haskell", fmt),
+    languages.registerDocumentFormattingEditProvider("haskell", fmt)
+  );
 }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -19,6 +19,12 @@ import {
   WorkspaceFolder
 } from "vscode";
 
+declare module "util" {
+  export function promisify<T>(
+    func: (data: any, cb: (err: NodeJS.ErrnoException, data?: T) => void,
+  ) => void): (...input: any[]) => Promise<T>;
+}
+
 export default class Formatter
   implements
     Disposable,
@@ -152,7 +158,7 @@ export default class Formatter
     console.log("brittany folder is: " + dir);
 
     try {
-      const { stdout, stderr } = await util.promisify(proc.execFile)(
+      const { stdout }: any = await util.promisify(proc.execFile)(
         cmdName,
         args,
         options

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -30,9 +30,7 @@ export default class Formatter
   private brittanyCmd: string = "brittany";
 
   constructor() {
-    console.log(`Awoken`);
     this.loadSettings();
-    console.log("Loaded Brittanies");
     workspace.onDidChangeConfiguration(
       (evt) => {
         if (evt.affectsConfiguration("brittany")) {
@@ -53,7 +51,6 @@ export default class Formatter
     options: FormattingOptions,
     token: CancellationToken
   ): Promise<TextEdit[]> {
-    console.log(`Formatting entire doc!`);
     return await this.provideDocumentRangeFormattingEdits(
       document,
       null,
@@ -68,21 +65,12 @@ export default class Formatter
     options: FormattingOptions,
     token: CancellationToken
   ): Promise<TextEdit[]> {
-    console.log(
-      `Formatting (partially) with brittany: ${JSON.stringify({
-        document,
-        options,
-        range,
-        token
-      })}`
-    );
     const edits: TextEdit[] = [];
     if (!this.isEnabled) {
       throw new Error("Brittany formatter not enabled");
     }
     // if document has CRLF line endings, change it to LF.
     if (!this.keepCRLF && document.eol === EndOfLine.CRLF) {
-      console.log("changing line endings to LF");
       edits.push(TextEdit.setEndOfLine(EndOfLine.LF));
     }
 
@@ -102,7 +90,6 @@ export default class Formatter
 
     const formatted: string = await this.runBrittany(input, document.fileName);
     edits.push(TextEdit.replace(range || fullRange, formatted));
-    console.log(`Edits: ${JSON.stringify(edits)}`);
     return edits;
   }
 
@@ -146,11 +133,7 @@ export default class Formatter
       encoding: "utf8"
     };
 
-    console.log("brittany command is: " + cmdName);
-    console.log("brittany folder is: " + dir);
-
     try {
-      console.log(`Invoking with: ${JSON.stringify([cmdName, args, options])}`);
       const child: any = child_proc.execFile(cmdName, args, options);
       if (stdin && stdin.length > 0) {
         child.stdin.write(stdin);
@@ -159,7 +142,6 @@ export default class Formatter
         child.stdin.end();
       }
       const { stdout, stderr }: any = await child;
-      console.log(`Result: ${stdout}`);
       const err: string = String(stderr);
       if (err.length > 0) {
         throw new Error(err);

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,181 @@
+import * as proc from "child_process";
+import * as path from "path";
+import * as tmp from "tmp";
+import * as util from "util";
+import {
+  CancellationToken,
+  commands,
+  Disposable,
+  DocumentFormattingEditProvider,
+  DocumentRangeFormattingEditProvider,
+  EndOfLine,
+  FormattingOptions,
+  Range,
+  TextDocument,
+  TextEdit,
+  window,
+  workspace,
+  WorkspaceEdit,
+  WorkspaceFolder
+} from "vscode";
+
+export default class Formatter
+  implements
+    Disposable,
+    DocumentRangeFormattingEditProvider,
+    DocumentFormattingEditProvider {
+  private disposables: Disposable[] = [];
+  private keepCRLF: boolean = false;
+  private isStackEnabled: boolean = false;
+  private isEnabled: boolean = true;
+  private additionalFlags: string = "";
+  private brittanyCmd: string = "brittany";
+
+  constructor() {
+    console.log(`Awoken`);
+    this.loadSettings();
+    console.log("Loaded Brittanies");
+    workspace.onDidChangeConfiguration(
+      (evt) => {
+        if (evt.affectsConfiguration("brittany")) {
+          this.loadSettings();
+        }
+      },
+      this,
+      this.disposables
+    );
+  }
+
+  public dispose(): void {
+    this.disposables.forEach((i) => i.dispose());
+  }
+
+  public async provideDocumentFormattingEdits(
+    document: TextDocument,
+    options: FormattingOptions,
+    token: CancellationToken
+  ): Promise<TextEdit[]> {
+    console.log(`Formatting`);
+    return await this.provideDocumentRangeFormattingEdits(
+      document,
+      null,
+      options,
+      token
+    );
+  }
+
+  public async provideDocumentRangeFormattingEdits(
+    document: TextDocument,
+    range: Range | null,
+    options: FormattingOptions,
+    token: CancellationToken
+  ): Promise<TextEdit[]> {
+    console.log(
+      `Formatting with brittany: ${JSON.stringify({
+        document,
+        options,
+        range,
+        token
+      })}`
+    );
+    const edits: TextEdit[] = [];
+    if (!this.isEnabled) {
+      throw new Error("Brittany formatter not enabled");
+    }
+    // if document has CRLF line endings, change it to LF.
+    if (!this.keepCRLF && document.eol === EndOfLine.CRLF) {
+      console.log("changing line endings to LF");
+      edits.push(TextEdit.setEndOfLine(EndOfLine.LF));
+    }
+
+    const fullRange: Range = this.fullDocumentRange(document);
+    const fullDoc: boolean = !range || range === fullRange;
+    let input: string | TextDocument;
+
+    if (fullDoc) {
+      if (document.isDirty) {
+        input = document.getText();
+      } else {
+        input = document;
+      }
+    } else {
+      input = document.getText(range);
+    }
+
+    const formatted: string = await this.runBrittany(input, document.fileName);
+    edits.push(TextEdit.replace(range || fullRange, formatted));
+    return edits;
+  }
+
+  private loadSettings(): void {
+    const config: any = workspace.getConfiguration("brittany");
+    this.keepCRLF = config.keepCRLF;
+    this.isStackEnabled = config.stackEnable;
+    this.isEnabled = config.enable;
+    this.additionalFlags = config.additionalFlags;
+    this.brittanyCmd = config.path;
+  }
+
+  private async runBrittany(
+    input: string | TextDocument,
+    inputFilename: string
+  ): Promise<string> {
+    let cmdName: string = "brittany";
+    const args: string[] = [];
+    let stdin: string | undefined;
+    let maybeWorkspaceFolder: WorkspaceFolder = null;
+
+    if (this.isStackEnabled) {
+      cmdName = "stack";
+      args.push("exec", "brittany", "--");
+    }
+    if (typeof input === "string") {
+      stdin = input;
+      args.push("--write-mode", "display");
+    } else {
+      args.push(input.uri.fsPath);
+      args.push("--write-mode", "display");
+      maybeWorkspaceFolder = workspace.getWorkspaceFolder(input.uri);
+    }
+
+    const dir: string =
+      maybeWorkspaceFolder !== undefined
+        ? maybeWorkspaceFolder.uri.fsPath
+        : workspace.rootPath;
+    const options: { cwd: string; encoding: string; stdin?: string } = {
+      cwd: dir,
+      encoding: "utf8",
+      stdin
+    };
+
+    console.log("brittany command is: " + cmdName);
+    console.log("brittany folder is: " + dir);
+
+    try {
+      const { stdout, stderr } = await util.promisify(proc.execFile)(
+        cmdName,
+        args,
+        options
+      );
+
+      return String(stdout);
+    } catch (error) {
+      {
+        console.error("Error running brittany:");
+        console.error(error);
+        window.showErrorMessage(
+          "Failed to run brittany; see the developer tools console for details. " +
+            error
+        );
+        throw new Error(
+          "Failed to run brittany; see the developer tools console for details."
+        );
+      }
+    }
+  }
+
+  private fullDocumentRange(document: TextDocument): Range {
+    const last: number = document.lineCount - 1;
+    return new Range(0, 0, last, document.lineAt(last).text.length);
+  }
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -162,7 +162,7 @@ export default class Formatter
       console.log(`Result: ${stdout}`);
       const err: string = String(stderr);
       if (err.length > 0) {
-        console.error(`Error: ${err}`);
+        throw new Error(err);
       }
 
       return String(stdout);


### PR DESCRIPTION
Recent VSCode provides different APIs for ranges and whole-file formatting.
This pull-request overcomes that change and switched to use stdin/out to avoid unnecessary saves.